### PR TITLE
Add support for chrome

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "web-ext": "^6.1.0",
     "web-ext-plugin": "^1.1.0",
     "web-ext-types": "^3.2.1",
+    "webextension-polyfill": "^0.8.0",
     "webpack": "^5.36.0",
     "webpack-cli": "^4.6.0"
   },

--- a/src/background_scripts/index.tsx
+++ b/src/background_scripts/index.tsx
@@ -17,7 +17,7 @@ async function dispatchRequest(request: any): Promise<any> {
   return result;
 }
 
-browser.runtime.onMessage.addListener((request: any, sender: any, response: any) => {
+browser.runtime.onMessage.addListener((request: any) => {
   const result = (async () => await dispatchRequest(request))();
-  response(result);
+  return result;
 });

--- a/src/popup/popup.tsx
+++ b/src/popup/popup.tsx
@@ -69,7 +69,7 @@ class Popup extends React.Component<PopupProps, PopupState> {
         command: "detect",
         url: tab.url,
       };
-      const providerType = await browser.tabs.sendMessage<any, ProviderType>(tab.id, request);
+      const providerType = await browser.runtime.sendMessage<any, ProviderType>(request);
 
       if (providerType !== undefined) {
         this.setState({
@@ -89,7 +89,7 @@ class Popup extends React.Component<PopupProps, PopupState> {
         type: this.state.providerType,
         url: tab.url,
       };
-      const songs = await browser.tabs.sendMessage<any, Song[]>(tab.id, request);
+      const songs = await browser.runtime.sendMessage<any, Song[]>(request);
 
       if (songs !== undefined) {
         this.setState({

--- a/src/public/manifest.json
+++ b/src/public/manifest.json
@@ -11,16 +11,12 @@
     "activeTab",
     "cookies"
   ],
-  "content_scripts": [
-    {
-      "matches": [
-        "<all_urls>"
-      ],
-      "js": [
-        "content.js"
-      ]
-    }
-  ],
+  "background": {
+    "scripts": [
+      "browser-polyfill.min.js",
+      "background.js"
+    ]
+  },
   "browser_action": {
     "default_icon": "icons/beasts-30.png",
     "default_title": "browser-extension",

--- a/src/public/popup.html
+++ b/src/public/popup.html
@@ -7,6 +7,7 @@
 
 <body>
   <div id="root"></div>
+  <script type="application/javascript" src="browser-polyfill.min.js"></script>
   <script src="popup.js"></script> <!-- must be after root -->
 </body>
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,7 @@ const WebExtPlugin = require('web-ext-plugin')
 
 const baseConfigs = {
   entry: {
-    content: path.resolve(__dirname, './src/content_scripts'),
+    background: path.resolve(__dirname, './src/background_scripts'),
     popup: path.resolve(__dirname, './src/popup'),
   },
   module: {
@@ -72,6 +72,9 @@ const baseConfigs = {
           globOptions: {
             ignore: ['*.js', '*.ts', '*.tsx'],
           },
+        },
+        {
+          from: 'node_modules/webextension-polyfill/dist/browser-polyfill.min.js',
         },
       ],
     }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -7008,6 +7008,11 @@ web-ext@^6.1.0:
     yargs "16.2.0"
     zip-dir "2.0.0"
 
+webextension-polyfill@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/webextension-polyfill/-/webextension-polyfill-0.8.0.tgz#f80e9f4b7f81820c420abd6ffbebfa838c60e041"
+  integrity sha512-a19+DzlT6Kp9/UI+mF9XQopeZ+n2ussjhxHJ4/pmIGge9ijCDz7Gn93mNnjpZAk95T4Tae8iHZ6sSf869txqiQ==
+
 webidl-conversions@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"


### PR DESCRIPTION
> Firefox also supports callbacks for the APIs that support the chrome.* namespace. However, using promises (and the browser.* namespace) is recommended. 

See also

- [Building a cross-browser extension](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Build_a_cross_browser_extension)
- [webextension-polyfill](https://github.com/mozilla/webextension-polyfill/)